### PR TITLE
Accommodate Microsoft.WindowsAppSDK.ML moving onnxruntime.lib in 1.8.2109+

### DIFF
--- a/build/cmake/microsoft.windowsappsdk.ml-config.cmake
+++ b/build/cmake/microsoft.windowsappsdk.ml-config.cmake
@@ -117,11 +117,19 @@ block(SCOPE_FOR VARIABLES)
         "${FRAMEWORK_PATH}/Microsoft.Windows.AI.MachineLearning.dll"
     )
 
-    set_target_properties(Microsoft.WindowsAppSDK.ML_SelfContainedRuntime
-        PROPERTIES
-            IMPORTED_IMPLIB     "${PACKAGE_LOCATION}/runtimes/win-${PLATFORM_IDENTIFIER}/native/onnxruntime.lib"
-            IMPORTED_LOCATION   "${FRAMEWORK_DLLS}"
-    )
+    if(PACKAGE_VERSION VERSION_GREATER_EQUAL "1.8.2109")
+        set_target_properties(Microsoft.WindowsAppSDK.ML_SelfContainedRuntime
+            PROPERTIES
+                IMPORTED_IMPLIB     "${PACKAGE_LOCATION}/lib/native/${PLATFORM_IDENTIFIER}/onnxruntime.lib"
+                IMPORTED_LOCATION   "${FRAMEWORK_DLLS}"
+        )
+    else()
+        set_target_properties(Microsoft.WindowsAppSDK.ML_SelfContainedRuntime
+            PROPERTIES
+                IMPORTED_IMPLIB     "${PACKAGE_LOCATION}/runtimes/win-${PLATFORM_IDENTIFIER}/native/onnxruntime.lib"
+                IMPORTED_LOCATION   "${FRAMEWORK_DLLS}"
+        )
+    endif()
 
     #[[====================================================================================================================
         Target: Microsoft.WindowsAppSDK.ML_SelfContained


### PR DESCRIPTION
In v1.8.2109 of `Microsoft.WindowsAppSDK.ML` the path to `onnxruntime.lib` changed to be more in-line with other NuGet packages. Accommodating that change here. This - of course - would be moot if this CMake logic were in the NuGet; need to continue refining the patterns in this repo before that move can happen.