### PR TITLE
Accommodate the move of Microsoft.UI.Dispatching.lib in 'Microsoft.WindowsAppSDK.InteractiveExperiences' 2.0+

### DIFF
--- a/build/cmake/microsoft.windowsappsdk.interactiveexperiences-config.cmake
+++ b/build/cmake/microsoft.windowsappsdk.interactiveexperiences-config.cmake
@@ -95,9 +95,19 @@ block(SCOPE_FOR VARIABLES)
         "${FRAMEWORK_PATH}/wuceffectsi.dll"
     )
 
+    if(PACKAGE_VERSION VERSION_GREATER_EQUAL "2.0")
+        set(FRAMEWORK_LIBS
+            "${PACKAGE_LOCATION}/lib/native/${PLATFORM_IDENTIFIER}/Microsoft.UI.Dispatching.lib"
+        )
+    else()
+        set(FRAMEWORK_LIBS
+            "${PACKAGE_LOCATION}/lib/native/win10-${PLATFORM_IDENTIFIER}/Microsoft.UI.Dispatching.lib"
+        )
+    endif()
+
     set_target_properties(Microsoft.WindowsAppSDK.InteractiveExperiences_SelfContainedRuntime
         PROPERTIES
-            IMPORTED_IMPLIB "${PACKAGE_LOCATION}/lib/native/win10-${PLATFORM_IDENTIFIER}/Microsoft.UI.Dispatching.lib"
+            IMPORTED_IMPLIB "${FRAMEWORK_LIBS}"
             IMPORTED_LOCATION "${FRAMEWORK_DLLS}"
     )
 


### PR DESCRIPTION
Fixes #10.

The 'overlay' for `Microsoft.WindowsAppSDK.InteractiveExperiences` needs to accommodate a 1.8 --> 2.0 change - the `Microsoft.UI.Dispatching.lib` file moved. Validated by building the [microsoft/WindowsAppSDK-Samples](https://github.com/microsoft/WindowsAppSDK-Samples), `Samples/WindowsML/cpp-cmake` folder, with the following NuGet packages:

* `Microsoft.Windows.CppWinRT` 2.0.240405.15
* `Microsoft.Windows.ImplementationLibrary` 1.0.260126.7
* `Microsoft.WindowsAppSDK.Foundation` 2.0.15-preview
* `Microsoft.WindowsAppSDK.InteractiveExperiences` 2.0.6-preview
* `Microsoft.WindowsAppSDK.ML` 2.0.175-preview
* `Microsoft.WindowsAppSDK.Runtime` 2.0.0-preview1
