### PR TITLE
Enforce CMake version through CMAKE_VERSION testing, not `cmake_minimum_required`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
 #[[====================================================================================================================
 ====================================================================================================================]]#
-cmake_minimum_required(VERSION 3.31)
 
 include_guard()
+
+# Check for minimum CMake version. Avoid using `cmake_minimum_required`, which will reset policies if this file is
+# included by a project that has already specified a minimum CMake version.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+    message(FATAL_ERROR "NuGetCMakePackage requires at least CMake 3.31, but CMake ${CMAKE_VERSION} is in use.")
+endif()
 
 define_property(VARIABLE
     PROPERTY NUGET_PACKAGE_ROOT_PATH

--- a/build/cmake/microsoft.windows.cppwinrt-config.cmake
+++ b/build/cmake/microsoft.windows.cppwinrt-config.cmake
@@ -18,7 +18,11 @@
 ====================================================================================================================]]#
 include_guard()
 
-cmake_minimum_required(VERSION 3.31)
+# Check for minimum CMake version. Avoid using `cmake_minimum_required`, which will reset policies if this file is
+# included by a project that has already specified a minimum CMake version.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+    message(FATAL_ERROR "Microsoft.Windows.CppWinRT requires at least CMake 3.31, but CMake ${CMAKE_VERSION} is in use.")
+endif()
 
 #[[====================================================================================================================
     add_cppwinrt_projection

--- a/build/cmake/microsoft.windows.implementationlibrary-config.cmake
+++ b/build/cmake/microsoft.windows.implementationlibrary-config.cmake
@@ -19,7 +19,11 @@
 ====================================================================================================================]]#
 include_guard()
 
-cmake_minimum_required(VERSION 3.31)
+# Check for minimum CMake version. Avoid using `cmake_minimum_required`, which will reset policies if this file is
+# included by a project that has already specified a minimum CMake version.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+    message(FATAL_ERROR "Microsoft.Windows.ImplementationLibrary requires at least CMake 3.31, but CMake ${CMAKE_VERSION} is in use.")
+endif()
 
 block(SCOPE_FOR VARIABLES)
     # For 'overlay' configuration, rely on the 'NUGET_LOCATION-<package name>' global property set by the NuGetCMakePackage.

--- a/build/cmake/microsoft.windowsappsdk.foundation-config.cmake
+++ b/build/cmake/microsoft.windowsappsdk.foundation-config.cmake
@@ -18,7 +18,11 @@
 ====================================================================================================================]]#
 include_guard()
 
-cmake_minimum_required(VERSION 3.31)
+# Check for minimum CMake version. Avoid using `cmake_minimum_required`, which will reset policies if this file is
+# included by a project that has already specified a minimum CMake version.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+    message(FATAL_ERROR "Microsoft.WindowsAppSDK.Foundation requires at least CMake 3.31, but CMake ${CMAKE_VERSION} is in use.")
+endif()
 
 find_package(Microsoft.Windows.CppWinRT CONFIG REQUIRED)
 find_package(Microsoft.WindowsAppSDK.InteractiveExperiences CONFIG REQUIRED)

--- a/build/cmake/microsoft.windowsappsdk.interactiveexperiences-config.cmake
+++ b/build/cmake/microsoft.windowsappsdk.interactiveexperiences-config.cmake
@@ -18,7 +18,11 @@
 ====================================================================================================================]]#
 include_guard()
 
-cmake_minimum_required(VERSION 3.31)
+# Check for minimum CMake version. Avoid using `cmake_minimum_required`, which will reset policies if this file is
+# included by a project that has already specified a minimum CMake version.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+    message(FATAL_ERROR "Microsoft.WindowsAppSDK.InteractiveExperiences requires at least CMake 3.31, but CMake ${CMAKE_VERSION} is in use.")
+endif()
 
 find_package(Microsoft.Windows.CppWinRT CONFIG REQUIRED)
 

--- a/build/cmake/microsoft.windowsappsdk.ml-config.cmake
+++ b/build/cmake/microsoft.windowsappsdk.ml-config.cmake
@@ -23,7 +23,11 @@
 ====================================================================================================================]]#
 include_guard()
 
-cmake_minimum_required(VERSION 3.31)
+# Check for minimum CMake version. Avoid using `cmake_minimum_required`, which will reset policies if this file is
+# included by a project that has already specified a minimum CMake version.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+    message(FATAL_ERROR "Microsoft.WindowsAppSDK.ML requires at least CMake 3.31, but CMake ${CMAKE_VERSION} is in use.")
+endif()
 
 find_package(Microsoft.Windows.CppWinRT CONFIG REQUIRED)
 find_package(Microsoft.WindowsAppSDK.Runtime CONFIG REQUIRED)

--- a/build/cmake/microsoft.windowsappsdk.runtime-config.cmake
+++ b/build/cmake/microsoft.windowsappsdk.runtime-config.cmake
@@ -18,7 +18,11 @@
 ====================================================================================================================]]#
 include_guard()
 
-cmake_minimum_required(VERSION 3.31)
+# Check for minimum CMake version. Avoid using `cmake_minimum_required`, which will reset policies if this file is
+# included by a project that has already specified a minimum CMake version.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+    message(FATAL_ERROR "Microsoft.WindowsAppSDK.Runtime requires at least CMake 3.31, but CMake ${CMAKE_VERSION} is in use.")
+endif()
 
 block(SCOPE_FOR VARIABLES)
     # For 'overlay' configuration, rely on the 'NUGET_LOCATION-<package name>' global property set by the NuGetCMakePackage.


### PR DESCRIPTION
As Copilot called out, CMake scripts that could be `include`'d shouldn't call [`cmake_minimum_required`](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html), since that can change the policy for the inclusion scope. Instead, they can check CMAKE_VERSION to ensure that the CMake version is sufficient.