### PR TITLE
Remove 'VERSION' from 'add_cppwinrt_projection'

### DIFF
--- a/build/cmake/microsoft.windows.cppwinrt-config.cmake
+++ b/build/cmake/microsoft.windows.cppwinrt-config.cmake
@@ -33,7 +33,6 @@ endif()
         add_cppwinrt_projection(<target>
             INPUTS <spec>+
             [DEPS <spec>+]
-            [VERSION <C++/WinRT version>]
             [PROJECTION_ROOT_PATH <path>]
             [OPTIMIZE]
         )
@@ -54,8 +53,6 @@ endif()
     target_link_libraries of this projection target, and any referenced cppwinrt inputs will be used for the
     -ref parameter to cppwinrt when generating this target's projection.
 
-    The VERSION parameter is optional, but if not specified the CPPWINRT_VERSION must be set.
-
     The PROJECTION_ROOT_PATH is optional. If not specified, and CPPWINRT_PROJECTION_ROOT_PATH is set, then the value of
     CPPWINRT_PROJECTION_ROOT_PATH will be used. If no value for PROJECTION_ROOT_PATH is specified, it will be defaulted
     to `${CMAKE_BINARY_DIR}/__cppwinrt`. Note: It is recommended that a custom value is specified outside of
@@ -64,7 +61,7 @@ endif()
 ====================================================================================================================]]#
 function(add_cppwinrt_projection TARGET_NAME)
     set(OPTIONS OPTIMIZE)
-    set(ONE_VALUE_KEYWORDS PROJECTION_ROOT_PATH VERSION PCH_NAME)
+    set(ONE_VALUE_KEYWORDS PROJECTION_ROOT_PATH PCH_NAME)
     set(MULTI_VALUE_KEYWORDS INPUTS DEPS)
 
     if(NOT TARGET_NAME)
@@ -72,10 +69,6 @@ function(add_cppwinrt_projection TARGET_NAME)
     endif()
 
     cmake_parse_arguments(PARSE_ARGV 1 CPPWINRT "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
-
-    if(NOT CPPWINRT_VERSION)
-        message(FATAL_ERROR "add_cppwinrt_projection: VERSION must be specified, or CPPWINRT_VERSION must be set.")
-    endif()
 
     if(NOT CPPWINRT_PROJECTION_ROOT_PATH)
         set(CPPWINRT_PROJECTION_ROOT_PATH ${CMAKE_BINARY_DIR}/__cppwinrt)
@@ -103,7 +96,6 @@ function(add_cppwinrt_projection TARGET_NAME)
         endforeach()
     endif()
 
-    message(VERBOSE "add_cppwinrt_projection: CPPWINRT_VERSION = ${CPPWINRT_VERSION}")
     message(VERBOSE "add_cppwinrt_projection: CPPWINRT_PROJECTION_ROOT_PATH = ${CPPWINRT_PROJECTION_ROOT_PATH}")
 
     # For 'overlay' configuration, rely on the 'NUGET_LOCATION-<package name>' global property set by the NuGetCMakePackage.


### PR DESCRIPTION
`add_cppwinrt_projection` has a `VERSION` parameter that _used to_ specify the version of the CppWinRT NuGet to download and use. Now that `add_cppwinrt_projection` is contained _within_ the NuGet (or - at least - an overlay), then the version is not needed. Infact, it's quite noisy - as of CMake 3.31, `cmake_parse_arguments` will set unspecified arguments to `""`, and so a 'default' `CPPWINRT_VERSION` won't fall through. The WindowsML samples 'worked around' this by forcing `CPPWINRT_VERSION` into the cache, but that's really difficult to spot; and completely unnecessary with this fix. Validated with the WindowsML/cpp-cmake build, without `CPPWINRT_VERSION` set in the presets file.