### PR TITLE
Add support for Microsoft.WindowsAppSDK.Foundation bootstrapper

### DIFF
--- a/overlay/microsoft.windowsappsdk.foundation/microsoft.windowsappsdk.foundation-config.cmake
+++ b/overlay/microsoft.windowsappsdk.foundation/microsoft.windowsappsdk.foundation-config.cmake
@@ -2,16 +2,30 @@
 
     Microsoft.WindowsAppSDK.Foundation
 
-    CMake configuration file for Microsoft.WindowsAppSDK.Foundation package.
-
-    This package provides CMake targets:
+    CMake configuration file for Microsoft.WindowsAppSDK.Foundation package. Use `find_package(Microsoft.WindowsAppSDK.Foundation CONFIG...)`
+    to load this package and its dependencies:
 
         find_package(Microsoft.WindowsAppSDK.Foundation CONFIG REQUIRED)
 
-        target_link_libraries(<your-target>
-            PRIVATE
-                Microsoft.WindowsAppSDK.Foundation
-        )
+    This package defines the following CMake targets:
+
+        * Microsoft.WindowsAppSDK.Foundation - A target representing the Cpp/WinRT projection, headers and libraries of
+            the Windows App SDK Foundation APIs. This does not include the necessary runtime components to use the
+            Windows App SDK, and is intended to be used by library authors who want to consume the Windows App SDK
+            Foundation APIs.
+
+        * Microsoft.WindowsAppSDK.Foundation_Framework - A target representing the Windows App SDK Foundation APIs that
+            also takes a dependency on the 'Framework Package' of the Windows App SDK. Target properties can be set on
+            _consuming_ target to control:
+                * `WindowsAppSdkBootstrapInitialize` - Whether to automatically initialize the Framework Package via
+                    the 'dynamic dependency' bootstrap logic.
+                * `WindowsAppSdkDeploymentManagerInitialize` - Whether to automatically initialize the Deployment
+                    Manager bootstrap logic.
+
+        * Microsoft.WindowsAppSDK.Foundation_SelfContained - An interface target that represents the Windows App SDK
+            Foundation APIs for self-contained deployment scenarios. Projects should normally link against this target,
+            which in turn depends on `Microsoft.WindowsAppSDK.Foundation_SelfContainedRuntime` to provide the required
+            implementation dependencies of the Windows App SDK.
 
     License:
         See the LICENSE file in the package root for more information.
@@ -89,6 +103,99 @@ block(SCOPE_FOR VARIABLES)
         INTERFACE
             ${PACKAGE_LOCATION}/include
     )
+
+    #[[====================================================================================================================
+        Target: Microsoft.WindowsAppSDK.Foundation_Framework
+    ====================================================================================================================]]#
+    add_library(Microsoft.WindowsAppSDK.Foundation_Framework INTERFACE)
+
+    target_link_libraries(Microsoft.WindowsAppSDK.Foundation_Framework
+        INTERFACE
+            Microsoft.WindowsAppSDK.Foundation
+    )
+
+    #[[====================================================================================================================
+        Targets:
+            Microsoft.WindowsAppSDK.Foundation_Bootstrap
+            Microsoft.WindowsAppSDK.Foundation_DynamicDependencyBootstrap
+            Microsoft.WindowsAppSDK.Foundation_DeploymentManagerBootstrap
+
+        Note: Consumers should not consume these targets directly. Instead, consume 'Microsoft.WindowsAppSDK.Foundation_Framework'
+        and set target properties on the _consuming_ target.
+
+        These targets need the Microsoft.WindowsAppSDK.Runtime package to be present. If the package cannot be found,
+        these targets will not be created, and the end-user will need to bootstrap the Framework manually.
+    ====================================================================================================================]]#
+    find_package(Microsoft.WindowsAppSDK.Runtime CONFIG QUIET)
+    if(NOT Microsoft.WindowsAppSDK.Runtime_FOUND)
+        message(VERBOSE "Microsoft.WindowsAppSDK.Runtime *not* found. The 'bootstrap' logic will *not* be available, and the Framework will need to be bootstrapped manually.")
+    else()
+        add_library(Microsoft.WindowsAppSDK.Foundation_Bootstrap SHARED IMPORTED GLOBAL)
+
+        target_sources(Microsoft.WindowsAppSDK.Foundation_Bootstrap
+            INTERFACE
+                "${PACKAGE_LOCATION}/include/WindowsAppRuntimeAutoInitializer.cpp"
+        )
+
+        set_target_properties(Microsoft.WindowsAppSDK.Foundation_Bootstrap
+            PROPERTIES
+                IMPORTED_IMPLIB "${PACKAGE_LOCATION}/lib/native/${PLATFORM_IDENTIFIER}/Microsoft.WindowsAppRuntime.Bootstrap.lib"
+                IMPORTED_LOCATION "${PACKAGE_LOCATION}/runtimes/win-${PLATFORM_IDENTIFIER}/native/Microsoft.WindowsAppRuntime.Bootstrap.dll"
+        )
+
+        target_link_libraries(Microsoft.WindowsAppSDK.Foundation_Bootstrap
+            INTERFACE
+                Microsoft.WindowsAppSDK.Runtime
+        )
+
+        # The 'Microsoft.WindowsAppSDK.Foundation_DynamicDependencyBootstrap' target adds the
+        # 'MddBootstrapAutoInitializer.cpp' source, and the MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_BOOTSTRAP
+        # preprocessor definition.
+        add_library(Microsoft.WindowsAppSDK.Foundation_DynamicDependencyBootstrap INTERFACE)
+
+        target_sources(Microsoft.WindowsAppSDK.Foundation_DynamicDependencyBootstrap
+            INTERFACE
+                "${PACKAGE_LOCATION}/include/MddBootstrapAutoInitializer.cpp"
+        )
+
+        target_compile_definitions(Microsoft.WindowsAppSDK.Foundation_DynamicDependencyBootstrap
+            INTERFACE
+                MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_BOOTSTRAP
+        )
+
+        target_link_libraries(Microsoft.WindowsAppSDK.Foundation_DynamicDependencyBootstrap
+            INTERFACE
+                Microsoft.WindowsAppSDK.Foundation_Bootstrap
+        )
+
+        # The 'Microsoft.WindowsAppSDK.Foundation_DeploymentManagerBootstrap' target adds the
+        # 'DeploymentManagerAutoInitializer.cpp' source, and the MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_DEPLOYMENTMANAGER
+        # preprocessor definition.
+        add_library(Microsoft.WindowsAppSDK.Foundation_DeploymentManagerBootstrap INTERFACE)
+
+        target_sources(Microsoft.WindowsAppSDK.Foundation_DeploymentManagerBootstrap
+            INTERFACE
+                "${PACKAGE_LOCATION}/include/DeploymentManagerAutoInitializer.cpp"
+        )
+
+        target_compile_definitions(Microsoft.WindowsAppSDK.Foundation_DeploymentManagerBootstrap
+            INTERFACE
+                MICROSOFT_WINDOWSAPPSDK_AUTOINITIALIZE_DEPLOYMENTMANAGER
+        )
+
+        target_link_libraries(Microsoft.WindowsAppSDK.Foundation_DeploymentManagerBootstrap
+            INTERFACE
+                Microsoft.WindowsAppSDK.Foundation_Bootstrap
+        )
+
+        # 'Microsoft.WindowsAppSDK.Foundation_Framework' should now depend on the individual bootstrap targets,
+        # conditional on properties of the consuming target.
+        target_link_libraries(Microsoft.WindowsAppSDK.Foundation_Framework
+            INTERFACE
+                $<$<BOOL:$<TARGET_PROPERTY:WindowsAppSdkBootstrapInitialize>>:Microsoft.WindowsAppSDK.Foundation_DynamicDependencyBootstrap>
+                $<$<BOOL:$<TARGET_PROPERTY:WindowsAppSdkDeploymentManagerInitialize>>:Microsoft.WindowsAppSDK.Foundation_DeploymentManagerBootstrap>
+        )
+    endif()
 
     #[[====================================================================================================================
         Target: Microsoft.WindowsAppSDK.Foundation_SelfContained


### PR DESCRIPTION
The `Microsoft.WindowsAppSDK.Foundation` NuGet package contains MSBuild/headers/source code/libs/dlls for 'bootstrapping' aspects of the Windows App SDK. This PR is to have a discussion as to how the support is surfaced.

A couple of points to discuss:
1. There's a little awkwardness around `Microsoft.WindowsAppSDK.Runtime`. The `Microsoft.WindowsAppSDK.Foundation` NuGet doesn't depend on the `Microsoft.WindowsAppSDK.Runtime` NuGet, but the bootstrapper code needs the `WindowsAppSDK-VersionInfo.h` from the `Microsoft.WindowsAppSDK.Runtime` NuGet. As a result, the CMake logic here checks to see if the `Microsoft.WindowsAppSDK.Runtime` CMake package is available, and only if it is, creates the `Microsoft.WindowsAppSDK.Foundation_FrameworkBootstrap` target. I couldn't find analogous logic in the MSBuild scripts, so I'm not really sure how it's handled.

2. This PR specifically adds support for the `WindowsAppSdkBootstrapInitialize`- and `WindowsAppSdkDeploymentManagerInitialize`- controlled bootstraps. In order to be able to accommodate multiple targets in a CMake build consuming `Microsoft.WindowsAppSDK.Foundation_Framework` with different configurations, I'm introducing generator-expression ([documentation](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html)) logic to the `Microsoft.WindowsAppSDK.Foundation_Framework` target, so that consumers can set properties on the target that control the functionality that the consuming target gets. This is a little complicated to implement, but yields - IMHO - a well encapsulated implementation, and is clean to consume. Basically, each option that affects the source/pre-processor defines that a consume can apply manifests as a different target. Then the `Microsoft.WindowsAppSDK.Foundation_Framework`-target will depend on each of those targets only if the consuming target has properties set:
    * If the consuming target sets `WindowsAppSdkBootstrapInitialize` property (named identically to the MSBuild property), then the `Microsoft.WindowsAppSDK.Foundation_Framework`-target will add a dependency on the `Microsoft.WindowsAppSDK.Foundation_DynamicDependencyBootstrap` target.
    * If the consuming target sets the `WindowsAppSdkDeploymentManagerInitialize` property then the `Microsoft.WindowsAppSDK.Foundation_Framework`-target will add a dependency on the `Microsoft.WindowsAppSDK.Foundation_DeploymentManagerBootstrap` target.

    This means that consumers don't have to manage multiple libraries, CMake builds aren't bound to CMake variables (which would only be evaluated on the first `find_package`). The implementation - whilst a little verbose - is quite nicely encapsulated and 'correct'. Here's a diagram that attempts to explain the target-graph

```mermaid
---
config:
  flowchart:
    defaultRenderer: elk
---
graph TD
    Framework["Foundation_Framework"]
    Foundation["Foundation"]
    DynDepBoot["Foundation_DynamicDependencyBootstrap"]
    DeployBoot["Foundation_DeploymentManagerBootstrap"]
    Bootstrap["Foundation_Bootstrap"]
    Runtime["Microsoft.WindowsAppSDK.Runtime"]

    Framework --> Foundation
    Framework -.->|"WindowsAppSdkBootstrapInitialize"| DynDepBoot
    Framework -.->|"WindowsAppSdkDeploymentManagerInitialize"| DeployBoot
    DynDepBoot --> Bootstrap
    DeployBoot --> Bootstrap
    Bootstrap --> Runtime
```

Consumers would write code like:

```cmake
# By linking to the '_Framework' variant of the Windows App SDK, the application will take a dependency on the Framework
# package for the Windows App SDK runtime.
#
target_link_libraries(Unpackaged_Console_Framework
    PRIVATE
        Microsoft.WindowsAppSDK.Foundation_Framework
        Microsoft.Windows.ImplementationLibrary
)

# Setting 'WindowsAppSdk*' target properties on _consumers_ of 'Microsoft.WindowsAppSDK.Foundation_Framework' controls
# the inclusion of the Windows App SDK Bootstrap infrastructure.
set_target_properties(Unpackaged_Console_Framework
    PROPERTIES
        # Controls whether the 'dynamic dependency' bootstrap will be added to the current target
        WindowsAppSdkBootstrapInitialize TRUE

        # Controls whether the 'deployment manager' bootstrap will be added to the current target
        WindowsAppSdkDeploymentManagerInitialize FALSE
)
```

I pushed a small self-contained buddy test [here](https://github.com/mschofie/NuGetCMakePackage_Samples/tree/mschofie/initial-sample) incase folks want to try things out. Note: this is based on the 'develop' branch, but this PR is for the 'main' branch.

I've validated with Ninja and Visual Studio 2022 generators. When both `WindowsAppSdkBootstrapInitialize` and `WindowsAppSdkDeploymentManagerInitialize` are unset or `FALSE`, the `Microsoft.WindowsAppRuntime.Bootstrap.dll` file isn't copied alongside the .exe. If either is `TRUE`, the file is copied, and the corresponding code is compiled into the consumer.